### PR TITLE
minor text edits

### DIFF
--- a/layouts/partials/countdown.html
+++ b/layouts/partials/countdown.html
@@ -3,7 +3,7 @@
 <section class="countdown-section">
     <div class="custom-counter">
         <div class="wrapper">
-            <h2><b>Get Ready for the Next GBCC</b></h2>
+            <h2><b>Get Ready for the GBCC</b></h2>
             <h3>June 23 (Mon.) - 26 (Thur.), 2025</h3>
             <ul class="countdown-timer" id="countdown">
                 <li><span id="days">0</span> DAYS</li>

--- a/layouts/partials/home-panels.html
+++ b/layouts/partials/home-panels.html
@@ -9,13 +9,10 @@
         </div>
         <ul>
             <li>
-                <a href="#">New Keynote Speaker Announced</a>
+                <a href="https://www.linkedin.com/posts/bioconductor_gbcc2025-logocontest-activity-7290808172653477888-WSJs">GBCC2025 Logo Design Winner Announced</a>
             </li>
             <li>
-                <a href="#">Call for Papers Extended</a>
-            </li>
-            <li>
-                <a href="#">Early Bird Registration Now Open</a>
+                <a href="https://blog.bioconductor.org/posts/2024-09-03-gbcc2025-announcement">GBCC2025: First Galaxy & Bioconductor Conference Announced</a>
             </li>
         </ul>
     </div>
@@ -26,7 +23,7 @@
         <ul>
             <li>
                 <div class="key_date_down">
-                    <div>January, 2025</div>
+                    <div>February 11 (Tues.), 2025</div>
                     <div>Abstract Submission Opens</div>
                 </div>
                 <div class="key_date_logo">

--- a/layouts/partials/news.html
+++ b/layouts/partials/news.html
@@ -7,6 +7,9 @@
                 <span class="highlight-text">Cold Spring Harbor Laboratory (CSHL), New York</span><br />
                 June 23-26, 2025
             </p>
+            <p class="text-small">
+                Interested in extending your stay? Join our <a href="/cofest" class="cofest-link">CoFest</a> on June 27-28!
+            </p>
         </div>
         
         <!-- Conference Info Section with Textured Background -->
@@ -15,10 +18,10 @@
             <div class="texture-overlay"></div>
             <div class="col-md-12">
                 <p>
-                    <b class="highlight-title">GBCC 2025</b> is the flagship annual conference for the Galaxy and Bioconductor projects. It serves as an exceptional opportunity to connect with scientists, researchers, software developers, and educators from various disciplines to exchange knowledge, experiences, and insights into the rapidly evolving fields of computational biology and bioinformatics.
+                    <b class="highlight-title">GBCC 2025</b> is the first-ever joint conference between the Galaxy and Bioconductor communities, bringing together two leading platforms in computational biology and bioinformatics. This unique event replaces both the traditional Bioconductor and Galaxy Community Conferences for 2025 (BioC2025 and GCC2025), offering an exceptional opportunity for scientists, researchers, software developers, and educators to connect, collaborate, and share knowledge.
                 </p>
                 <p>
-                    This year’s conference will feature a rich program, including keynote addresses, invited talks, poster sessions, hands-on workshops, and Birds of a Feather sessions. The event will take place at the esteemed Cold Spring Harbor Laboratory in New York, providing a unique setting for both collaboration and learning.
+                    The 2025 conference will feature a rich program, including keynote addresses, invited talks, poster sessions, hands-on workshops, and Birds of a Feather sessions. The event will take place at the esteemed Cold Spring Harbor Laboratory in New York, providing a unique setting for both collaboration and learning.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
- Replaced placeholder news items with:
[GBCC2025 Logo Design Winner Announced](https://www.linkedin.com/posts/bioconductor_gbcc2025-logocontest-activity-7290808172653477888-WSJs)
[GBCC2025: First Galaxy & Bioconductor Conference Announced](https://blog.bioconductor.org/posts/2024-09-03-gbcc2025-announcement)
- Added February 11, 2025, as the abstract submission opening date in Key Dates.
- Included CoFest link (June 27-28) in the homepage hero section.
- Clarified that GBCC 2025 replaces BioC2025 and GCC2025 in the homepage description.