### PR TITLE
fix cofest link

### DIFF
--- a/layouts/partials/news.html
+++ b/layouts/partials/news.html
@@ -8,7 +8,7 @@
                 June 23-26, 2025
             </p>
             <p class="text-small">
-                Interested in extending your stay? Join our <a href="/cofest" class="cofest-link">CoFest</a> on June 27-28!
+                Interested in extending your stay? Join our <a href="/cofest/overview" class="cofest-link">CoFest</a> on June 27-28!
             </p>
         </div>
 


### PR DESCRIPTION
currently it goes to https://gbcc2025.bioconductor.org/cofest which is empty