### PR TITLE
fix: update footer email link to a mailto

### DIFF
--- a/themes/hugo-universal-theme/layouts/partials/footer.html
+++ b/themes/hugo-universal-theme/layouts/partials/footer.html
@@ -68,7 +68,7 @@
         <h4 style="color: #FFFFFF;">Contact Information</h4>
         <p style="color: #F5F1E3;">
           GBCC2025 Organizing Committee<br />
-          Email: <a href="gbcc2025-org@gaggle.email" style="color: #6C91C2;">gbcc2025-org@gaggle.email</a><br />
+          Email: <a href="mailto:gbcc2025-org@gaggle.email" style="color: #6C91C2;">gbcc2025-org@gaggle.email</a><br />
           Website: <a href="https://gbcc2025.org" style="color: #6C91C2;">www.gbcc2025.org</a>
         </p>
       </div>


### PR DESCRIPTION
Otherwise clicking on this link yields a:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/fcad158f-5798-4554-bb11-814560857e28" />
